### PR TITLE
Fix #3: If condition trailing call

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,5 +1,4 @@
 - adjust heredoc/heregex indent with surrounding indentation level
-- preserve 2e308 (or anything else that would compile to Infinity)?
 - how do elisions and breaking arrays interplay?
 - make comma option less naive (eg either omit or dedent comma if the arg has indentation eg breaking function or control)
 - where to draw the line with what to parenthesize when splatting - you can omit a lot of parens but it looks weird eg [(a if f)?.b ? []...]
@@ -88,17 +87,6 @@
   which it wants to convert to:
   schema: [enum: ['object', 'property']]
 - if singleQuote, prefer ''' to """ for TemplateLiterals with no interpolations
-- this is broken:
-  if a.some((b) ->
-    c
-    d
-  )
-    e
-  formats as:
-  if a.some (b) ->
-    c
-    d
-    e
 - unnecessary parens:
   currentNode[(
     if a
@@ -210,3 +198,9 @@
     else
       b
   )]
+- this shouldn't want to linebreak the {:
+  addProps = (updater) -> (props) -> {
+    ...props
+    ...(if isFunction updater then updater props else updater)
+  }
+- options for no implicit parens/objects

--- a/tests/call-parens/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/call-parens/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,91 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`trailing-call-in-condition.coffee 1`] = `
+if a((b) ->
+  c
+  d
+)
+  e
+
+e if a((b) ->
+  c
+  d
+)
+
+while a((b) ->
+  c
+  d
+)
+  e
+
+e while a((b) ->
+  c
+  d
+)
+
+for f in a((b) ->
+  c
+  d
+)
+  e
+
+e for f in a((b) ->
+  c
+  d
+)
+
+switch a((b) ->
+  c
+  d
+)
+  when e then f
+
+class A extends a((b) ->
+  c
+  d
+)
+  e: 1
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+if a((b) ->
+  c
+  d
+)
+  e
+
+e if a (b) ->
+  c
+  d
+
+while a((b) ->
+  c
+  d
+)
+  e
+
+e while a (b) ->
+  c
+  d
+
+for f in a((b) ->
+  c
+  d
+)
+  e
+
+e for f in a (b) ->
+  c
+  d
+
+switch a((b) ->
+  c
+  d
+)
+  when e then f
+
+class A extends a((b) ->
+  c
+  d
+)
+  e: 1
+
+`;

--- a/tests/call-parens/jsfmt.spec.js
+++ b/tests/call-parens/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ['coffeescript'])

--- a/tests/call-parens/trailing-call-in-condition.coffee
+++ b/tests/call-parens/trailing-call-in-condition.coffee
@@ -1,0 +1,44 @@
+if a((b) ->
+  c
+  d
+)
+  e
+
+e if a((b) ->
+  c
+  d
+)
+
+while a((b) ->
+  c
+  d
+)
+  e
+
+e while a((b) ->
+  c
+  d
+)
+
+for f in a((b) ->
+  c
+  d
+)
+  e
+
+e for f in a((b) ->
+  c
+  d
+)
+
+switch a((b) ->
+  c
+  d
+)
+  when e then f
+
+class A extends a((b) ->
+  c
+  d
+)
+  e: 1


### PR DESCRIPTION
In this PR:
- fix #3 (trailing call with single function/`do` IIFE arg in line that can be followed by indented body needs parens)
- special-case `switch` condition to inline call expression (similar to eg `while`)