### PR TITLE
Don't double-parenthesize conditional breaking condition

### DIFF
--- a/TODO
+++ b/TODO
@@ -66,16 +66,6 @@
     else
       ...
   )]
-  also:
-  unless (
-    (
-      if a
-        ...
-      else
-       ...
-    )
-  )
-    ...
 - postfix if can break:
   return Object.assign state,
     inCharClass: yes, startingCharClass: yes if (

--- a/tests/coffeescript_tests/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/coffeescript_tests/__snapshots__/jsfmt.spec.js.snap
@@ -9876,7 +9876,7 @@ test "basic \`while\` loops", ->
   ok results.join(" ") is "16 12 8 4"
 
 test "Issue 759: \`if\` within \`while\` condition", ->
-  2 while if 1 then 0
+  2 while (if 1 then 0)
 
 test "assignment inside the condition of a \`while\` loop", ->
   nonce = {}

--- a/tests/parens/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/parens/__snapshots__/jsfmt.spec.js.snap
@@ -74,3 +74,92 @@ b while (
 )
 
 `;
+
+exports[`conditional-condition.coffee 1`] = `
+if (
+  if a
+    b
+  else
+    c
+)
+  d
+
+unless (if a then b)
+  c
+
+c if (
+  if a
+    b
+)
+
+while (
+  if a
+    b
+  else
+    c
+)
+  d
+
+until (if a then b)
+  c
+
+c while (
+  if a
+    b
+)
+
+switch (
+  if a
+    b
+  else
+    c
+)
+  when d then e
+
+switch (if a then b)
+  when c then d
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+if (
+  if a
+    b
+  else
+    c
+)
+  d
+
+unless (if a then b)
+  c
+
+c if (
+  if a
+    b
+)
+
+while (
+  if a
+    b
+  else
+    c
+)
+  d
+
+until (if a then b)
+  c
+
+c while (
+  if a
+    b
+)
+
+switch (
+  if a
+    b
+  else
+    c
+)
+  when d then e
+
+switch (if a then b)
+  when c then d
+
+`;

--- a/tests/parens/conditional-condition.coffee
+++ b/tests/parens/conditional-condition.coffee
@@ -1,0 +1,42 @@
+if (
+  if a
+    b
+  else
+    c
+)
+  d
+
+unless (if a then b)
+  c
+
+c if (
+  if a
+    b
+)
+
+while (
+  if a
+    b
+  else
+    c
+)
+  d
+
+until (if a then b)
+  c
+
+c while (
+  if a
+    b
+)
+
+switch (
+  if a
+    b
+  else
+    c
+)
+  when d then e
+
+switch (if a then b)
+  when c then d


### PR DESCRIPTION
 Fixes #21

Also added parens for inline conditional condition (on `while`/`switch`, they were already added on `if`) eg
```
1 while if 1 then 0
```
formats as
```
1 while (if 1 then 0)
```