### PR TITLE
Can omit call parens in switch case test

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -325,6 +325,8 @@ function pathNeedsParens(path, options, {stackOffset = 0} = {}) {
           return true
         case 'AssignmentExpression':
           return isPostfixBody(path, {stackOffset: 1})
+        case 'SwitchCase':
+          return parent.test === node
         default:
           return false
       }
@@ -2500,6 +2502,7 @@ function isRightmostInStatement(
           prevParent === parent.alternate)) ||
       (parent.type === 'SwitchStatement' &&
         prevParent === parent.discriminant) ||
+      (parent.type === 'SwitchCase' && prevParent === parent.test) ||
       (parent.type === 'For' &&
         (prevParent === parent.source || prevParent === parent.guard)) ||
       (parent.type === 'WhileStatement' && prevParent === parent.test) ||

--- a/tests/call-parens/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/call-parens/__snapshots__/jsfmt.spec.js.snap
@@ -94,6 +94,65 @@ return g(
 
 `;
 
+exports[`switch-case-condition.coffee 1`] = `
+switch
+  when b c
+    d
+
+switch
+  when b c then d
+
+switch
+  when b(c if e)
+    d
+
+switch
+  when b(c if e) then d
+
+switch
+  when (b(c) if e)
+    d
+
+switch
+  when (b(c) if e) then d
+
+switch
+  when (if b then e)
+    d
+
+switch
+  when (if b then e) then d
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+switch
+  when b c
+    d
+
+switch
+  when b c then d
+
+switch
+  when b (c if e)
+    d
+
+switch
+  when b (c if e) then d
+
+switch
+  when (b c if e)
+    d
+
+switch
+  when (b c if e) then d
+
+switch
+  when (if b then e)
+    d
+
+switch
+  when (if b then e) then d
+
+`;
+
 exports[`trailing-call-in-condition.coffee 1`] = `
 if a((b) ->
   c

--- a/tests/call-parens/switch-case-condition.coffee
+++ b/tests/call-parens/switch-case-condition.coffee
@@ -1,0 +1,27 @@
+switch
+  when b c
+    d
+
+switch
+  when b c then d
+
+switch
+  when b(c if e)
+    d
+
+switch
+  when b(c if e) then d
+
+switch
+  when (b(c) if e)
+    d
+
+switch
+  when (b(c) if e) then d
+
+switch
+  when (if b then e)
+    d
+
+switch
+  when (if b then e) then d


### PR DESCRIPTION
Fixes #66 

Ended up being ok to omit call parens even for inline cases (eg `when a b then c`)