### PR TITLE
Can omit call parens on last array item

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2432,6 +2432,14 @@ function shouldOmitObjectBraces(
     return ifParentBreaks
   }
 
+  if (
+    parent.type === 'ArrayExpression' &&
+    node === getLast(parent.elements) &&
+    parent.elements.length > 1
+  ) {
+    return ifParentBreaks ? {indent: false} : false
+  }
+
   let isRightmost
   if (
     (isRightmost = isRightmostInStatement(path, options, {
@@ -2517,7 +2525,7 @@ function isRightmostInStatement(
       (parent.type === 'MemberExpression' &&
         prevParent === parent.property &&
         parent.computed) ||
-      (parent.type === 'ArrayExpression' && parent.elements.length === 1)
+      (parent.type === 'ArrayExpression' && node === getLast(parent.elements))
     ) {
       return {
         indent,

--- a/tests/call-parens/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/call-parens/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`array.coffee 1`] = `
+[
+  a b
+  c d
+]
+
+[a(bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb), c(ddddddddddddddddddddddddddddddddddddddd)]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[a(b), c d]
+
+[
+  a bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  c ddddddddddddddddddddddddddddddddddddddd
+]
+
+`;
+
 exports[`existence.coffee 1`] = `
 a(b)?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/call-parens/array.coffee
+++ b/tests/call-parens/array.coffee
@@ -1,0 +1,6 @@
+[
+  a b
+  c d
+]
+
+[a(bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb), c(ddddddddddddddddddddddddddddddddddddddd)]


### PR DESCRIPTION
 Fixes #72

But looks better not to omit object braces (on object which is last item of a nonbreaking array), which is why I'd "added this special case" originally