### PR TITLE
Inline function right side of logical expression

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2907,6 +2907,10 @@ function shouldInlineLogicalExpression(node, {notJSX} = {}) {
     return true
   }
 
+  if (isFunction(node.right)) {
+    return true
+  }
+
   if (!notJSX && isJSXNode(node.right)) {
     return true
   }

--- a/tests/binary-expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/binary-expressions/__snapshots__/jsfmt.spec.js.snap
@@ -145,6 +145,27 @@ if (
 
 `;
 
+exports[`inline-function.coffee 1`] = `
+a = b ? ->
+  c
+
+a = b or ->
+  c
+
+exports.some = Array::some ? (fn) ->
+  b
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+a = b ? ->
+  c
+
+a = b or ->
+  c
+
+exports.some = Array::some ? (fn) ->
+  b
+
+`;
+
 exports[`inline-jsx.coffee 1`] = `
 user = renderedUser or <div><User name={@state.user.name} age={@state.user.age} /></div>
 

--- a/tests/binary-expressions/inline-function.coffee
+++ b/tests/binary-expressions/inline-function.coffee
@@ -1,0 +1,8 @@
+a = b ? ->
+  c
+
+a = b or ->
+  c
+
+exports.some = Array::some ? (fn) ->
+  b


### PR DESCRIPTION
Fixes #44 

Following existing logic, only inlined for `LogicalExpression` (not `BinaryExpression`, which probably doesn't have any use cases?)