### PR TITLE
Parenthesize assignment to postfix if

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -306,13 +306,14 @@ function pathNeedsParens(path, options, {stackOffset = 0} = {}) {
         //   return !node.postfix
 
         case 'ObjectProperty':
-          if (!node.postfix) {
-            return false
+          if (
+            node.postfix &&
+            node === parent.value &&
+            grandparent.properties.length === 1
+          ) {
+            return {unlessParentBreaks: {visibleType: 'assignment'}}
           }
-          if (grandparent.properties.length === 1) {
-            return true
-          }
-          return {unlessParentBreaks: true}
+          return false
         case 'NewExpression':
         case 'CallExpression':
           if (node !== parent.callee && node !== getLast(parent.arguments)) {
@@ -348,13 +349,14 @@ function pathNeedsParens(path, options, {stackOffset = 0} = {}) {
           }
           return false
         case 'ObjectProperty':
-          if (!node.postfix) {
-            return false
+          if (
+            node.postfix &&
+            node === parent.value &&
+            grandparent.properties.length === 1
+          ) {
+            return {unlessParentBreaks: {visibleType: 'assignment'}}
           }
-          if (grandparent.properties.length === 1) {
-            return true
-          }
-          return {unlessParentBreaks: true}
+          return false
         case 'ReturnStatement':
         case 'MemberExpression':
         case 'SpreadElement':
@@ -367,6 +369,18 @@ function pathNeedsParens(path, options, {stackOffset = 0} = {}) {
       switch (parent.type) {
         case 'AssignmentExpression':
           if (node.postfix) {
+            return {unlessParentBreaks: {visibleType: 'assignment'}}
+          }
+          return false
+        case 'ObjectProperty':
+          if (
+            node.postfix &&
+            node === parent.value &&
+            grandparent.properties.length === 1
+          ) {
+            return {unlessParentBreaks: {visibleType: 'assignment'}}
+          }
+          if (!node.postfix) {
             return {unlessParentBreaks: {visibleType: 'assignment'}}
           }
           return false

--- a/src/printer.js
+++ b/src/printer.js
@@ -343,7 +343,10 @@ function pathNeedsParens(path, options, {stackOffset = 0} = {}) {
         case 'CallExpression':
           return parent.callee === node || node.postfix
         case 'AssignmentExpression':
-          return node.postfix
+          if (node.postfix) {
+            return {unlessParentBreaks: {visibleType: 'assignment'}}
+          }
+          return false
         case 'ObjectProperty':
           if (!node.postfix) {
             return false
@@ -363,7 +366,10 @@ function pathNeedsParens(path, options, {stackOffset = 0} = {}) {
     case 'WhileStatement':
       switch (parent.type) {
         case 'AssignmentExpression':
-          return node.postfix
+          if (node.postfix) {
+            return {unlessParentBreaks: {visibleType: 'assignment'}}
+          }
+          return false
         case 'SpreadElement':
         case 'JSXSpreadAttribute':
           return true

--- a/tests/coffeescript_tests/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/coffeescript_tests/__snapshots__/jsfmt.spec.js.snap
@@ -20599,7 +20599,7 @@ test '#1871: implicit object closed by IMPLICIT_END in implicit returns', ->
   # instead these return an object
   func = ->
     key:
-      (i for i in [1, 2, 3])
+      i for i in [1, 2, 3]
 
   eq func().key.join(' '), '1 2 3'
 

--- a/tests/coffeescript_tests/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/coffeescript_tests/__snapshots__/jsfmt.spec.js.snap
@@ -848,7 +848,7 @@ test 'for-from comprehensions over Array', ->
   ok array1.join(' ') is '35 55'
 
   array2 =
-    (a + b for [a, b] from [[10, 20], [30, 40], [50, 60]] when a + b >= 70)
+    a + b for [a, b] from [[10, 20], [30, 40], [50, 60]] when a + b >= 70
   ok array2.join(' ') is '70 110'
 
 `;

--- a/tests/parens/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/parens/__snapshots__/jsfmt.spec.js.snap
@@ -106,11 +106,31 @@ a = (b if c)
 
 a =
   bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb if ccccccccc
+
+a = (b while c)
+
+a =
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb while cccccc
+
+a = (b for b in c)
+
+a =
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb for b in ccc
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 a = (b if c)
 
 a =
   bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb if ccccccccc
+
+a = (b while c)
+
+a =
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb while cccccc
+
+a = (b for b in c)
+
+a =
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb for b in ccc
 
 `;
 

--- a/tests/parens/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/parens/__snapshots__/jsfmt.spec.js.snap
@@ -116,6 +116,83 @@ a = (b for b in c)
 
 a =
   bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb for b in ccc
+
+a: (b if c)
+
+BREAK
+
+a: (b if c)
+d: e
+
+BREAK
+
+d: e
+a: (b if c)
+
+BREAK
+
+a:
+  b if c
+
+BREAK
+
+a:
+  b if c
+d: e
+
+BREAK
+
+a: (b while c)
+
+BREAK
+
+a: (b while c)
+d: e
+
+BREAK
+
+a:
+  b while c
+
+BREAK
+
+a:
+  b while c
+d: e
+
+BREAK
+
+a: (while b then c)
+
+BREAK
+
+a: (while b then c)
+d: e
+
+BREAK
+
+a:
+  while b
+    c
+
+BREAK
+
+a: (b for b in c)
+
+BREAK
+
+a: (b for b in c)
+d: e
+
+BREAK
+
+a:
+  b for b in c
+
+BREAK
+
+a: (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb for b in cccc)
+d: e
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 a = (b if c)
 
@@ -131,6 +208,84 @@ a = (b for b in c)
 
 a =
   bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb for b in ccc
+
+a: (b if c)
+
+BREAK
+
+a: b if c
+d: e
+
+BREAK
+
+d: e
+a: b if c
+
+BREAK
+
+a:
+  b if c
+
+BREAK
+
+a:
+  b if c
+d: e
+
+BREAK
+
+a: (b while c)
+
+BREAK
+
+a: b while c
+d: e
+
+BREAK
+
+a:
+  b while c
+
+BREAK
+
+a:
+  b while c
+d: e
+
+BREAK
+
+a: (while b then c)
+
+BREAK
+
+a: (while b then c)
+d: e
+
+BREAK
+
+a:
+  while b
+    c
+
+BREAK
+
+a: (b for b in c)
+
+BREAK
+
+a: b for b in c
+d: e
+
+BREAK
+
+a:
+  b for b in c
+
+BREAK
+
+a:
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb for b in cccc
+d: e
 
 `;
 

--- a/tests/parens/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/parens/__snapshots__/jsfmt.spec.js.snap
@@ -101,6 +101,19 @@ c while a = b
 
 `;
 
+exports[`assignment-to-postfix-if.coffee 1`] = `
+a = (b if c)
+
+a =
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb if ccccccccc
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+a = (b if c)
+
+a =
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb if ccccccccc
+
+`;
+
 exports[`conditional-computed-access.coffee 1`] = `
 a[if b then c]
 

--- a/tests/parens/assignment-to-postfix-if.coffee
+++ b/tests/parens/assignment-to-postfix-if.coffee
@@ -1,0 +1,4 @@
+a = (b if c)
+
+a =
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb if ccccccccc

--- a/tests/parens/assignment-to-postfix-if.coffee
+++ b/tests/parens/assignment-to-postfix-if.coffee
@@ -2,3 +2,13 @@ a = (b if c)
 
 a =
   bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb if ccccccccc
+
+a = (b while c)
+
+a =
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb while cccccc
+
+a = (b for b in c)
+
+a =
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb for b in ccc

--- a/tests/parens/assignment-to-postfix-if.coffee
+++ b/tests/parens/assignment-to-postfix-if.coffee
@@ -12,3 +12,80 @@ a = (b for b in c)
 
 a =
   bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb for b in ccc
+
+a: (b if c)
+
+BREAK
+
+a: (b if c)
+d: e
+
+BREAK
+
+d: e
+a: (b if c)
+
+BREAK
+
+a:
+  b if c
+
+BREAK
+
+a:
+  b if c
+d: e
+
+BREAK
+
+a: (b while c)
+
+BREAK
+
+a: (b while c)
+d: e
+
+BREAK
+
+a:
+  b while c
+
+BREAK
+
+a:
+  b while c
+d: e
+
+BREAK
+
+a: (while b then c)
+
+BREAK
+
+a: (while b then c)
+d: e
+
+BREAK
+
+a:
+  while b
+    c
+
+BREAK
+
+a: (b for b in c)
+
+BREAK
+
+a: (b for b in c)
+d: e
+
+BREAK
+
+a:
+  b for b in c
+
+BREAK
+
+a: (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb for b in cccc)
+d: e


### PR DESCRIPTION
Fixes #83 

Also applies to postfix `for`/`while`

And for all of those, applies to object properties too (not just regular `=` assignment)

Made it only parenthesize if assignment doesn't break