### PR TITLE
Inline assignment of computed member expression

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -4097,6 +4097,9 @@ function printAssignment(
     rightNode.type === 'NewExpression' ||
     (rightNode.type === 'AssignmentExpression' &&
       node.type === 'AssignmentExpression') ||
+    (rightNode.type === 'MemberExpression' &&
+      rightNode.computed &&
+      rightNode.object.type === 'Identifier') ||
     (rightNode.type === 'CallExpression' &&
       (rightNode.callee.type === 'Identifier' ||
         rightNode.callee.type === 'MemberExpression'))

--- a/tests/assignment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/assignment/__snapshots__/jsfmt.spec.js.snap
@@ -49,6 +49,21 @@ butThisOneShould =
 
 `;
 
+exports[`member-expression.coffee 1`] = `
+aaaaaaaaaaaaa = bbbbbbbbbbbbbbb[if ccccccccccccccc then ddddddddddd else eeeeeeeee]
+
+aaaaaaaaaaaaa: bbbbbbbbbbbbbbb[if ccccccccccccccc then ddddddddddd else eeeeeeeee]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+aaaaaaaaaaaaa = bbbbbbbbbbbbbbb[
+  if ccccccccccccccc then ddddddddddd else eeeeeeeee
+]
+
+aaaaaaaaaaaaa: bbbbbbbbbbbbbbb[
+  if ccccccccccccccc then ddddddddddd else eeeeeeeee
+]
+
+`;
+
 exports[`tagged-template-literal.coffee 1`] = `
 a = '''
   b

--- a/tests/assignment/member-expression.coffee
+++ b/tests/assignment/member-expression.coffee
@@ -1,0 +1,3 @@
+aaaaaaaaaaaaa = bbbbbbbbbbbbbbb[if ccccccccccccccc then ddddddddddd else eeeeeeeee]
+
+aaaaaaaaaaaaa: bbbbbbbbbbbbbbb[if ccccccccccccccc then ddddddddddd else eeeeeeeee]


### PR DESCRIPTION
Fixes #86 

For now only "simple" computed member expressions (where the object is an `Identifier`) are inlined - might be nice to inline more complex ones if they didn't break eg
```
a = b.c[
  d
]
```
but currently this could break like
```
a = b
.c[d]
```
So don't know how hard it would be to only inline it if it didn't break until (possibly at) the computed property?