### PR TITLE
Support new.target

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -824,6 +824,12 @@ function printPathNoParens(path, options, print) {
             ),
       ])
     }
+    case 'MetaProperty':
+      return concat([
+        path.call(print, 'meta'),
+        '.',
+        path.call(print, 'property'),
+      ])
     case 'SpreadElement':
     case 'RestElement':
       return concat([

--- a/tests/meta-property/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/meta-property/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`new-target.coffee 1`] = `
+->
+  new.target
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+->
+  new.target
+
+`;

--- a/tests/meta-property/jsfmt.spec.js
+++ b/tests/meta-property/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ['coffeescript'])

--- a/tests/meta-property/new-target.coffee
+++ b/tests/meta-property/new-target.coffee
@@ -1,0 +1,2 @@
+->
+  new.target


### PR DESCRIPTION
Fixes #85 

`import.meta` is not yet supported by Coffeescript but should just work once supported since now `MetaProperty` nodes are handled