### PR TITLE
Elision shouldn't be dedented comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ yarn:
 # yarn seems to occasionally get confused by Github dependencies, so I'd recommend clearing your lockfile first
 rm yarn.lock
 # then explicitly install the dependencies and the plugin
-yarn add --dev github:helixbass/coffeescript#c8cfbfe6 github:helixbass/prettier#72ae1f97 prettier-plugin-coffeescript
+yarn add --dev github:helixbass/coffeescript#63d127c github:helixbass/prettier#72ae1f97 prettier-plugin-coffeescript
 ```
 
 npm:
@@ -41,7 +41,7 @@ npm:
 # npm also seems to occasionally get confused by Github dependencies, so I'd recommend clearing your lockfile first
 rm package-lock.json
 # then explicitly install the dependencies and the plugin
-npm install --save-dev github:helixbass/coffeescript#c8cfbfe6 github:helixbass/prettier#72ae1f97 prettier-plugin-coffeescript
+npm install --save-dev github:helixbass/coffeescript#63d127c github:helixbass/prettier#72ae1f97 prettier-plugin-coffeescript
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">= 6"
   },
   "dependencies": {
-    "coffeescript": "github:helixbass/coffeescript#c8cfbfe6",
+    "coffeescript": "github:helixbass/coffeescript#63d127c",
     "prettier": "github:helixbass/prettier#72ae1f97"
   },
   "devDependencies": {

--- a/src/printer.js
+++ b/src/printer.js
@@ -4733,21 +4733,23 @@ function isDoFunc(node) {
   return isDo(node) && isFunction(node.argument)
 }
 
-function getSeparatorParts({dedentFollowingComma, options}) {
+function getSeparatorParts({dedentFollowingComma, options, isCommaRequired}) {
   return [
-    ifBreak(
-      dedentFollowingComma
-        ? dedentFollowingComma.ifBreak
-          ? ifBreak(dedent(concat([line, ','])), '', {
-              visibleType: 'itemWithComma',
-            })
-          : dedent(concat([line, ',']))
-        : options.comma !== 'none'
-        ? ','
-        : '',
-      ',',
-      {visibleType: 'visible'}
-    ),
+    isCommaRequired
+      ? ','
+      : ifBreak(
+          dedentFollowingComma
+            ? dedentFollowingComma.ifBreak
+              ? ifBreak(dedent(concat([line, ','])), '', {
+                  visibleType: 'itemWithComma',
+                })
+              : dedent(concat([line, ',']))
+            : options.comma !== 'none'
+            ? ','
+            : '',
+          ',',
+          {visibleType: 'visible'}
+        ),
     dedentFollowingComma && dedentFollowingComma.ifBreak ? '' : line,
   ]
 }
@@ -5052,8 +5054,13 @@ function printArrayItems(path, options, printPath, print) {
     }
     printedElements.push(print(childPath))
 
+    const isElision = child == null
     if (!isLast) {
-      separatorParts = getSeparatorParts({dedentFollowingComma, options})
+      separatorParts = getSeparatorParts({
+        dedentFollowingComma,
+        options,
+        isCommaRequired: isElision,
+      })
       if (!shouldBreakArray) {
         shouldBreakArray = child && isFunction(child)
       }
@@ -5063,7 +5070,7 @@ function printArrayItems(path, options, printPath, print) {
       groupPreviousChildWithItsComma = dedentFollowingComma.ifBreak
     }
     childIndex++
-    precedingIsElision = child == null
+    precedingIsElision = isElision
   }, printPath)
 
   return {

--- a/src/printer.js
+++ b/src/printer.js
@@ -5020,6 +5020,7 @@ function printArrayItems(path, options, printPath, print) {
   let alwaysBreak
   let childIndex = 0
   const lastIndex = elements && elements.length && elements.length - 1
+  let precedingIsElision = false
   path.each(childPath => {
     const child = childPath.getValue()
     const isLast = childIndex === lastIndex
@@ -5031,7 +5032,7 @@ function printArrayItems(path, options, printPath, print) {
     if (!isLast && alwaysBreak) {
       shouldBreakArray = true
     }
-    if (dedentPrecedingComma) {
+    if (dedentPrecedingComma && !precedingIsElision) {
       if (separatorParts.length) {
         separatorParts[0] = ifBreak(dedent(concat([line, ','])), ',')
       }
@@ -5062,6 +5063,7 @@ function printArrayItems(path, options, printPath, print) {
       groupPreviousChildWithItsComma = dedentFollowingComma.ifBreak
     }
     childIndex++
+    precedingIsElision = child == null
   }, printPath)
 
   return {

--- a/tests/comma/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comma/__snapshots__/jsfmt.spec.js.snap
@@ -57,6 +57,138 @@ f
 
 `;
 
+exports[`elision.coffee 1`] = `
+[a, , , b]
+
+[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, , , bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb]
+
+[, , ,]
+
+[, , , c]
+
+[, , , ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc]
+
+[, , , ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc: d, ,]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[a, , , b]
+
+[
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+]
+
+[, , ,]
+
+[, , , c]
+
+[
+
+
+
+  ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+]
+
+[
+
+
+
+  ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc: d
+,
+  ,
+]
+
+`;
+
+exports[`elision.coffee 2`] = `
+[a, , , b]
+
+[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, , , bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb]
+
+[, , ,]
+
+[, , , c]
+
+[, , , ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc]
+
+[, , , ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc: d, ,]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[a, , , b]
+
+[
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+  ,
+  ,
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+]
+
+[, , ,]
+
+[, , , c]
+
+[
+  ,
+  ,
+  ,
+  ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+]
+
+[
+  ,
+  ,
+  ,
+  ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc: d
+,
+  ,
+]
+
+`;
+
+exports[`elision.coffee 3`] = `
+[a, , , b]
+
+[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, , , bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb]
+
+[, , ,]
+
+[, , , c]
+
+[, , , ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc]
+
+[, , , ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc: d, ,]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[a, , , b]
+
+[
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+  ,
+  ,
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+]
+
+[, , ,]
+
+[, , , c]
+
+[
+  ,
+  ,
+  ,
+  ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc,
+]
+
+[
+  ,
+  ,
+  ,
+  ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc: d
+,
+  ,
+]
+
+`;
+
 exports[`function.coffee 1`] = `
 [-> b]
 

--- a/tests/comma/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comma/__snapshots__/jsfmt.spec.js.snap
@@ -74,8 +74,8 @@ exports[`elision.coffee 1`] = `
 
 [
   aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-
-
+  ,
+  ,
   bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 ]
 
@@ -84,16 +84,16 @@ exports[`elision.coffee 1`] = `
 [, , , c]
 
 [
-
-
-
+  ,
+  ,
+  ,
   ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 ]
 
 [
-
-
-
+  ,
+  ,
+  ,
   ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc: d
 ,
   ,

--- a/tests/comma/elision.coffee
+++ b/tests/comma/elision.coffee
@@ -1,0 +1,11 @@
+[a, , , b]
+
+[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, , , bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb]
+
+[, , ,]
+
+[, , , c]
+
+[, , , ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc]
+
+[, , , ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc: d, ,]

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,14 +74,14 @@
   integrity sha512-SPBKHUHvaFINuzmxFgtVC+Yj3w2qAzS3+gsm9M0M2NkbTGdL/xz3SKWUeyhrGNMJ7sb2l49BzdLbAKFq+5DIZw==
 
 "@types/node@*":
-  version "11.13.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.5.tgz#266564afa8a6a09dc778dfacc703ed3f09c80516"
-  integrity sha512-/OMMBnjVtDuwX1tg2pkYVSqRIDSmNTnvVvmvP/2xiMAAWf4a5+JozrApCrO4WCAILmXVxfNoQ3E+0HJbNpFVGg==
+  version "11.13.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.6.tgz#37ec75690830acb0d74ce3c6c43caab787081e85"
+  integrity sha512-Xoo/EBzEe8HxTSwaZNLZjaW6M6tA/+GmD3/DZ6uo8qSaolE/9Oarko0oV1fVfrLqOz0tx0nXJB4rdD5c+vixLw==
 
 "@types/node@^10.11.7":
-  version "10.14.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.4.tgz#1c586b991457cbb58fef51bc4e0cfcfa347714b5"
-  integrity sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg==
+  version "10.14.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.5.tgz#27733a949f5d9972d87109297cffb62207ace70f"
+  integrity sha512-Ja7d4s0qyGFxjGeDq5S7Si25OFibSAHUi6i17UWnwNnpitADN7hah9q0Tl25gxuV5R1u2Bx+np6w4LHXfHyj/g==
 
 "@types/semver@^5.5.0":
   version "5.5.0"
@@ -785,9 +785,9 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-"coffeescript@github:helixbass/coffeescript#c8cfbfe6":
+"coffeescript@github:helixbass/coffeescript#63d127c":
   version "2.3.2"
-  resolved "https://codeload.github.com/helixbass/coffeescript/tar.gz/c8cfbfe673dd11909c85d22ad0231352cf341093"
+  resolved "https://codeload.github.com/helixbass/coffeescript/tar.gz/63d127cf6921b703445825e00a758511c7886e64"
   dependencies:
     babel-eslint "^7.2.2"
     babylon "^7.0.0-beta.44"
@@ -4706,9 +4706,9 @@ typescript@3.0.1:
   integrity sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==
 
 uglify-js@^3.1.4:
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.5.4.tgz#4a64d57f590e20a898ba057f838dcdfb67a939b9"
-  integrity sha512-GpKo28q/7Bm5BcX9vOu4S46FwisbPbAmkkqPnGIpKvKTM96I85N6XHQV+k4I6FA2wxgLhcsSyHoNhzucwCflvA==
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.5.5.tgz#9c5aaaf3a7586fbf559df31fa6d3bca1b3ba7e9b"
+  integrity sha512-e58FqZzPwaLODQetDQKlvErZaGkh1UmzP8YwU0aG65NLourKNtwVyDG8tkIyUU0vqWzxaikSvTaxrCSscmvqvQ==
   dependencies:
     commander "~2.20.0"
     source-map "~0.6.1"


### PR DESCRIPTION
Fixes #117 

Coffeescript didn't support breaking leading elisions eg:
```
[
  ,
  ,
  b
]
```
so opened https://github.com/jashkenas/coffeescript/pull/5202 and updated Coffeescript dependency to include that branch