### PR TITLE
Parenthesize nested inline if when parent has alternate

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -303,15 +303,21 @@ function pathNeedsParens(path, options, {stackOffset = 0} = {}) {
       if (isCondition(node, parent)) {
         return {unlessParentBreaks: true}
       }
-      if (node.alternate) {
-        const isRightmost = isRightmostInStatement(path, options, {
-          stackOffset,
-          checkIfIsConsequent: true,
-        })
-        if (isRightmost && isRightmost.isConsequent) {
-          return {unlessParentBreaks: {visibleType: 'if'}}
-        }
+
+      const isRightmost = isRightmostInStatement(path, options, {
+        stackOffset,
+        checkIfIsConsequent: true,
+      })
+      if (
+        isRightmost &&
+        isRightmost.isConsequent &&
+        (node.alternate ||
+          (isRightmost.isConsequent.ifNode &&
+            isRightmost.isConsequent.ifNode.alternate))
+      ) {
+        return {unlessParentBreaks: {visibleType: 'if'}}
       }
+
       switch (parent.type) {
         case 'TaggedTemplateExpression':
         case 'Range':
@@ -2772,7 +2778,7 @@ function isIfConsequent(path, {stackOffset = 0, postfix} = {}) {
   const greatgrandparent = path.getParentNode(stackOffset + 2)
 
   if (isIf(parent, {postfix}) && node === parent.consequent) {
-    return true
+    return {ifNode: parent}
   }
 
   if (
@@ -2780,7 +2786,7 @@ function isIfConsequent(path, {stackOffset = 0, postfix} = {}) {
     isIf(grandparent, {postfix}) &&
     parent === grandparent.consequent
   ) {
-    return true
+    return {ifNode: grandparent}
   }
 
   if (
@@ -2789,7 +2795,7 @@ function isIfConsequent(path, {stackOffset = 0, postfix} = {}) {
     isIf(greatgrandparent, {postfix}) &&
     grandparent === greatgrandparent.consequent
   ) {
-    return true
+    return {ifNode: greatgrandparent}
   }
 
   return false

--- a/tests/if/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/if/__snapshots__/jsfmt.spec.js.snap
@@ -49,10 +49,19 @@ x = if true then id(a + if false then undefined else nonce)
 
 if true then id(if false then undefined)
 
+if true then id(if false then undefined) else no
+
 x = if true then id(if false then undefined)
+
+x = if true then id(if false then undefined) else no
 
 if true
   id(if false then undefined else nonce)
+
+x = if true
+  id(if false then undefined)
+else
+  no
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 if true then id (if false then undefined else nonce)
 
@@ -68,10 +77,19 @@ x = if true then id a + (if false then undefined else nonce)
 
 if true then id if false then undefined
 
+if true then id (if false then undefined) else no
+
 x = if true then id if false then undefined
+
+x = if true then id (if false then undefined) else no
 
 if true
   id if false then undefined else nonce
+
+x = if true
+  id if false then undefined
+else
+  no
 
 `;
 

--- a/tests/if/nested-inline.coffee
+++ b/tests/if/nested-inline.coffee
@@ -12,7 +12,16 @@ x = if true then id(a + if false then undefined else nonce)
 
 if true then id(if false then undefined)
 
+if true then id(if false then undefined) else no
+
 x = if true then id(if false then undefined)
+
+x = if true then id(if false then undefined) else no
 
 if true
   id(if false then undefined else nonce)
+
+x = if true
+  id(if false then undefined)
+else
+  no


### PR DESCRIPTION
Fixes #56 

This extends #120 to also parenthesize when the parent has an `else` since although not a bug it's confusing to read