### PR TITLE
JSX namespaced names

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1899,6 +1899,11 @@ function printPathNoParens(path, options, print) {
       return concat(parts)
     case 'JSXIdentifier':
       return '' + n.name
+    case 'JSXNamespacedName':
+      return join(':', [
+        path.call(print, 'namespace'),
+        path.call(print, 'name'),
+      ])
     case 'JSXSpreadAttribute':
       return concat([
         '{',

--- a/tests/jsx-namespaced-names/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-namespaced-names/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`names.coffee 1`] = `
+<namespace:div />
+
+<namespace:div>{content}</namespace:div>
+
+<div namespace:attr />
+
+<div namespace:attr="value" />
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<namespace:div />
+
+<namespace:div>{content}</namespace:div>
+
+<div namespace:attr />
+
+<div namespace:attr="value" />
+
+`;

--- a/tests/jsx-namespaced-names/jsfmt.spec.js
+++ b/tests/jsx-namespaced-names/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ['coffeescript'])

--- a/tests/jsx-namespaced-names/names.coffee
+++ b/tests/jsx-namespaced-names/names.coffee
@@ -1,0 +1,7 @@
+<namespace:div />
+
+<namespace:div>{content}</namespace:div>
+
+<div namespace:attr />
+
+<div namespace:attr="value" />


### PR DESCRIPTION
Fixes #128 

Adds support for JSX namespaced names eg `<a:b c:d="e" />`