### PR TITLE
Handle comma breaking dedented

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -4362,7 +4362,14 @@ function printArgumentsList(path, options, print) {
       shouldBreak = true
     }
     if (dedentPrecedingComma && !(isLast && isObjectish(arg))) {
-      if (separatorParts.length) {
+      if (
+        separatorParts.length &&
+        !(
+          separatorParts[0].type === 'if-break' &&
+          separatorParts[0].breakContents &&
+          separatorParts[0].breakContents.type === 'if-break'
+        )
+      ) {
         separatorParts[0] = ifBreak(dedent(concat([line, ','])), ',')
       }
     }

--- a/tests/comma/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comma/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,101 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`breaking-dedented.coffee 1`] = `
+flow((b -> valllllllllllllllllllllllllllllllllllllllllllllllllllllll), -> 4444444444444)
+
+f((-> valllllllllllllllllllllllllllllllllllllllllllllllllllllll), -> 444444444444444444)
+
+f(
+  ->
+    val
+    2
+  -> 4
+)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+flow(
+  b -> valllllllllllllllllllllllllllllllllllllllllllllllllllllll
+  -> 4444444444444
+)
+
+f(
+  -> valllllllllllllllllllllllllllllllllllllllllllllllllllllll
+  -> 444444444444444444
+)
+
+f(
+  ->
+    val
+    2
+,
+  -> 4
+)
+
+`;
+
+exports[`breaking-dedented.coffee 2`] = `
+flow((b -> valllllllllllllllllllllllllllllllllllllllllllllllllllllll), -> 4444444444444)
+
+f((-> valllllllllllllllllllllllllllllllllllllllllllllllllllllll), -> 444444444444444444)
+
+f(
+  ->
+    val
+    2
+  -> 4
+)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+flow(
+  b -> valllllllllllllllllllllllllllllllllllllllllllllllllllllll
+  -> 4444444444444
+)
+
+f(
+  -> valllllllllllllllllllllllllllllllllllllllllllllllllllllll
+  -> 444444444444444444
+)
+
+f(
+  ->
+    val
+    2
+,
+  -> 4
+)
+
+`;
+
+exports[`breaking-dedented.coffee 3`] = `
+flow((b -> valllllllllllllllllllllllllllllllllllllllllllllllllllllll), -> 4444444444444)
+
+f((-> valllllllllllllllllllllllllllllllllllllllllllllllllllllll), -> 444444444444444444)
+
+f(
+  ->
+    val
+    2
+  -> 4
+)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+flow(
+  b -> valllllllllllllllllllllllllllllllllllllllllllllllllllllll
+  -> 4444444444444
+)
+
+f(
+  -> valllllllllllllllllllllllllllllllllllllllllllllllllllllll
+  -> 444444444444444444
+)
+
+f(
+  ->
+    val
+    2
+,
+  -> 4
+)
+
+`;
+
 exports[`call.coffee 1`] = `
 # breaking implicit should never have trailing comma
 

--- a/tests/comma/breaking-dedented.coffee
+++ b/tests/comma/breaking-dedented.coffee
@@ -1,0 +1,10 @@
+flow((b -> valllllllllllllllllllllllllllllllllllllllllllllllllllllll), -> 4444444444444)
+
+f((-> valllllllllllllllllllllllllllllllllllllllllllllllllllllll), -> 444444444444444444)
+
+f(
+  ->
+    val
+    2
+  -> 4
+)


### PR DESCRIPTION
In this PR:
- handle an issue where a comma was getting incorrectly printed eg:
```
ret =
  flowMax(
    returns (val) -> val + 2 ,
    -> 4
  ) 1
```