### PR TITLE
Export implicit

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3163,6 +3163,8 @@ function isRightmostInStatement(
       (parent.type === 'For' &&
         (prevParent === parent.source || prevParent === parent.guard)) ||
       (parent.type === 'WhileStatement' && prevParent === parent.test) ||
+      (parent.type === 'ExportNamedDeclaration' &&
+        prevParent === parent.declaration) ||
       (parent.type === 'ClassExpression' &&
         prevParent === parent.superClass &&
         ((parent.body && parent.body.body.length) ||
@@ -4491,13 +4493,15 @@ function printArgumentsList(path, options, print) {
     isPostfixIfConsequent(path) ||
     (parent.type === 'ReturnStatement' &&
       isPostfixIfConsequent(path, {stackOffset: 1}))
+  const isExportDefault = parent.type === 'ExportDefaultDeclaration'
 
   const unnecessary =
     shouldntBreak ||
     (firstArgIsObject &&
       !isRightSideOfAssignment &&
       !isFollowedByIndentedBody(node, parent) &&
-      !isPostfixIfBody)
+      !isPostfixIfBody &&
+      !isExportDefault)
 
   const parensUnnecessary = unnecessary && parensOptional
   const parensUnnecessaryIfParentBreaks =

--- a/tests/export/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/export/__snapshots__/jsfmt.spec.js.snap
@@ -57,3 +57,85 @@ export {}
 export {} from '.'
 
 `;
+
+exports[`implicit.coffee 1`] = `
+export ActionTypes =
+  A: null
+  B: null
+  C: null
+
+export default ActionTypes =
+  A: null
+  B: null
+  C: null
+
+export d = f
+  a: 1
+  b: 2
+
+export default f
+  a: 1
+  b: 2
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export ActionTypes =
+  A: null
+  B: null
+  C: null
+
+export default ActionTypes =
+  A: null
+  B: null
+  C: null
+
+export d = f(
+  a: 1
+  b: 2
+)
+
+export default f(
+  a: 1
+  b: 2
+)
+
+`;
+
+exports[`implicit.coffee 2`] = `
+export ActionTypes =
+  A: null
+  B: null
+  C: null
+
+export default ActionTypes =
+  A: null
+  B: null
+  C: null
+
+export d = f
+  a: 1
+  b: 2
+
+export default f
+  a: 1
+  b: 2
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export ActionTypes =
+  A: null
+  B: null
+  C: null
+
+export default ActionTypes =
+  A: null
+  B: null
+  C: null
+
+export d = f(
+  a: 1
+  b: 2
+)
+
+export default f(
+  a: 1
+  b: 2
+)
+
+`;

--- a/tests/export/implicit.coffee
+++ b/tests/export/implicit.coffee
@@ -1,0 +1,17 @@
+export ActionTypes =
+  A: null
+  B: null
+  C: null
+
+export default ActionTypes =
+  A: null
+  B: null
+  C: null
+
+export d = f
+  a: 1
+  b: 2
+
+export default f
+  a: 1
+  b: 2


### PR DESCRIPTION
Fixes #140 

In this PR:
- named export is rightmost (so eg can end with implicit object)
- don't omit call parens for export default call + breaking implicit first object