### PR TITLE
Break object property with chained value

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -4849,11 +4849,15 @@ function dontBreakAssignment({
       node.type === 'AssignmentExpression') ||
     (options.indentChain &&
       isMemberExpression(rightNode) &&
-      !isSimpleMemberExpression(rightNode, node)) ||
+      !isSimpleMemberExpression(rightNode, node) &&
+      // here and below, avoid Coffeescript parsing chain as being applied to object rather than key
+      node.type !== 'ObjectProperty') ||
     // &&
     // rightNode.computed &&
     // rightNode.object.type === 'Identifier'
-    (options.indentChain && isChainableCall(rightNode)) ||
+    (options.indentChain &&
+      isChainableCall(rightNode) &&
+      node.type !== 'ObjectProperty') ||
     (isCallExpression(rightNode) &&
       (!isChainableCall(rightNode) ||
         !path.call(

--- a/tests/assignment-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/assignment-chain/__snapshots__/jsfmt.spec.js.snap
@@ -23,6 +23,10 @@ aaaaaaaaa: bbbbbbbb.ccccccccc(-> d).eeeeeeeeeeeeeeeeeeeeeeee.fffffffffffffffffff
 
 a = b.c (d) ->
   e
+
+ruleTester.run "#{ruleName}:strict", rule,
+  valid: [...alwaysValid].map(ruleOptionsMapperFactory strictOptions).map(parserOptionsMapper)
+  invalid: [...neverValid].map(ruleOptionsMapperFactory strictOptions).map parserOptionsMapper
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
   bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.cccccccccccccccccc
@@ -39,27 +43,39 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
 aaaaaaaaa = bbbbbbbb().ccccccccc(-> d).eeeeeeeeeeeeeeeeeeeeeeee
   .fffffffffffffffffffffffff
 
-aaaaaaaaa: bbbbbbbb().ccccccccc(-> d).eeeeeeeeeeeeeeeeeeeeeeee
-  .fffffffffffffffffffffffff
+aaaaaaaaa:
+  bbbbbbbb().ccccccccc(-> d).eeeeeeeeeeeeeeeeeeeeeeee.fffffffffffffffffffffffff
 
 aaaaaaaaa = bbbbbbbb()
   .ccccccccc(-> d)
   .eeeeeeeeeeeeeeeeeeeeeeee.fffffffffffffffffffffffff()
 
-aaaaaaaaa: bbbbbbbb()
-  .ccccccccc(-> d)
-  .eeeeeeeeeeeeeeeeeeeeeeee.fffffffffffffffffffffffff()
+aaaaaaaaa:
+  bbbbbbbb()
+    .ccccccccc(-> d)
+    .eeeeeeeeeeeeeeeeeeeeeeee.fffffffffffffffffffffffff()
 
 aaaaaaaaa = bbbbbbbb
   .ccccccccc(-> d)
   .eeeeeeeeeeeeeeeeeeeeeeee.fffffffffffffffffffffffff()
 
-aaaaaaaaa: bbbbbbbb
-  .ccccccccc(-> d)
-  .eeeeeeeeeeeeeeeeeeeeeeee.fffffffffffffffffffffffff()
+aaaaaaaaa:
+  bbbbbbbb
+    .ccccccccc(-> d)
+    .eeeeeeeeeeeeeeeeeeeeeeee.fffffffffffffffffffffffff()
 
 a = b.c (d) ->
   e
+
+ruleTester.run "#{ruleName}:strict", rule,
+  valid:
+    [...alwaysValid]
+      .map(ruleOptionsMapperFactory strictOptions)
+      .map(parserOptionsMapper)
+  invalid:
+    [...neverValid]
+      .map(ruleOptionsMapperFactory strictOptions)
+      .map parserOptionsMapper
 
 `;
 
@@ -86,6 +102,10 @@ aaaaaaaaa: bbbbbbbb.ccccccccc(-> d).eeeeeeeeeeeeeeeeeeeeeeee.fffffffffffffffffff
 
 a = b.c (d) ->
   e
+
+ruleTester.run "#{ruleName}:strict", rule,
+  valid: [...alwaysValid].map(ruleOptionsMapperFactory strictOptions).map(parserOptionsMapper)
+  invalid: [...neverValid].map(ruleOptionsMapperFactory strictOptions).map parserOptionsMapper
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
   bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.cccccccccccccccccc
@@ -127,5 +147,15 @@ aaaaaaaaa:
 
 a = b.c (d) ->
   e
+
+ruleTester.run "#{ruleName}:strict", rule,
+  valid:
+    [...alwaysValid]
+    .map(ruleOptionsMapperFactory strictOptions)
+    .map(parserOptionsMapper)
+  invalid:
+    [...neverValid]
+    .map(ruleOptionsMapperFactory strictOptions)
+    .map parserOptionsMapper
 
 `;

--- a/tests/assignment-chain/chain.coffee
+++ b/tests/assignment-chain/chain.coffee
@@ -20,3 +20,7 @@ aaaaaaaaa: bbbbbbbb.ccccccccc(-> d).eeeeeeeeeeeeeeeeeeeeeeee.fffffffffffffffffff
 
 a = b.c (d) ->
   e
+
+ruleTester.run "#{ruleName}:strict", rule,
+  valid: [...alwaysValid].map(ruleOptionsMapperFactory strictOptions).map(parserOptionsMapper)
+  invalid: [...neverValid].map(ruleOptionsMapperFactory strictOptions).map parserOptionsMapper

--- a/tests/assignment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/assignment/__snapshots__/jsfmt.spec.js.snap
@@ -58,9 +58,8 @@ aaaaaaaaaaaaa = bbbbbbbbbbbbbbb[
   if ccccccccccccccc then ddddddddddd else eeeeeeeee
 ]
 
-aaaaaaaaaaaaa: bbbbbbbbbbbbbbb[
-  if ccccccccccccccc then ddddddddddd else eeeeeeeee
-]
+aaaaaaaaaaaaa:
+  bbbbbbbbbbbbbbb[if ccccccccccccccc then ddddddddddd else eeeeeeeee]
 
 `;
 

--- a/tests/coffeescript_tests/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/coffeescript_tests/__snapshots__/jsfmt.spec.js.snap
@@ -13791,7 +13791,8 @@ test 'method call chaining inside objects', ->
   f = (x) -> c: 42
   result =
     a: f 1
-    b: f(a: 1).c
+    b:
+      f(a: 1).c
   eq 42, result.b
 
 test '#4568: refine sameLine implicit object tagging', ->


### PR DESCRIPTION
Fixes #144 

In this PR:
- don't avoid breaking object properties with chainable values (avoids the Coffeescript parsing issue where it wants to apply chains to an entire object rather than just the property value)