### PR TITLE
Print empty block semicolon with comments

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1160,17 +1160,15 @@ function printPathNoParens(path, options, print) {
       const hasDirectives = n.directives && n.directives.length > 0
 
       const parent = path.getParentNode()
-      if (
+      const needsSemicolon =
         !hasContent &&
-        !hasDirectives &&
-        !hasDanglingComments(n) &&
         (((parent.type === 'IfStatement' ||
           parent.type === 'ConditionalExpression') &&
           n === parent.consequent &&
           !parent.alternate) ||
           ((parent.type === 'WhileStatement' || parent.type === 'For') &&
             n === parent.body))
-      ) {
+      if (!hasDirectives && !hasDanglingComments(n) && needsSemicolon) {
         return indent(concat([hardline, ';']))
       }
 
@@ -1210,11 +1208,7 @@ function printPathNoParens(path, options, print) {
 
       parts.push(comments.printDanglingComments(path, options))
 
-      if (
-        !hasContent &&
-        (parent.type === 'WhileStatement' || parent.type === 'For') &&
-        n === parent.body
-      ) {
+      if (needsSemicolon) {
         parts.push(indent(concat([hardline, ';'])))
       }
       return concat(parts)

--- a/src/util.js
+++ b/src/util.js
@@ -101,16 +101,23 @@ function hasSameStartLine(node, other) {
   return node.loc.start.line === other.loc.start.line
 }
 
-function getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd) {
+function getNextNonSpaceNonCommentCharacterIndexWithStartIndex(text, idx) {
   let oldIdx = null
-  let idx = locEnd(node)
-  while (idx !== oldIdx) {
-    oldIdx = idx
-    idx = skipSpaces(text, idx)
-    idx = skipInlineComment(text, idx)
-    idx = skipNewline(text, idx)
+  let nextIdx = idx
+  while (nextIdx !== oldIdx) {
+    oldIdx = nextIdx
+    nextIdx = skipSpaces(text, nextIdx)
+    nextIdx = skipInlineComment(text, nextIdx)
+    nextIdx = skipNewline(text, nextIdx)
   }
-  return idx
+  return nextIdx
+}
+
+function getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd) {
+  return getNextNonSpaceNonCommentCharacterIndexWithStartIndex(
+    text,
+    locEnd(node)
+  )
 }
 
 function getNextNonSpaceNonCommentCharacter(text, node, locEnd) {
@@ -131,5 +138,6 @@ module.exports = {
   isNextLineEmpty,
   hasSameStartLine,
   getNextNonSpaceNonCommentCharacter,
+  getNextNonSpaceNonCommentCharacterIndexWithStartIndex,
   isFunction,
 }

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -197,6 +197,106 @@ expect(=> {}).toTriggerReadyStateChanges [
 
 `;
 
+exports[`empty.coffee 1`] = `
+if a
+  # preceding
+  ;
+
+if a
+  ; # trailing
+
+if a
+  ;
+  # next line
+
+while a
+  # preceding
+  ;
+
+while a
+  ; # trailing
+
+while a
+  ;
+  # next line
+
+for a in b
+  # preceding
+  ;
+
+for a in b
+  ; # trailing
+
+for a in b
+  ;
+  # next line
+
+switch
+  when b
+    # preceding
+    ;
+
+switch
+  when b
+    ; # trailing
+
+switch
+  when b
+    ;
+    # next line
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+if a
+  # preceding
+  ;
+
+if a
+  # trailing
+  ;
+
+if a
+  # next line
+  ;
+
+while a
+  # preceding
+  ;
+
+while a
+  # trailing
+  ;
+
+while a
+  # next line
+  ;
+
+for a in b
+  # preceding
+  ;
+
+for a in b
+  # trailing
+  ;
+
+for a in b
+  # next line
+  ;
+
+switch
+  when b
+  # preceding
+    ;
+
+switch
+  when b # trailing
+    ;
+
+switch
+  when b
+  # next line
+    ;
+
+`;
+
 exports[`export.coffee 1`] = `
 export ### comment ### {}
 

--- a/tests/comments/empty.coffee
+++ b/tests/comments/empty.coffee
@@ -1,0 +1,46 @@
+if a
+  # preceding
+  ;
+
+if a
+  ; # trailing
+
+if a
+  ;
+  # next line
+
+while a
+  # preceding
+  ;
+
+while a
+  ; # trailing
+
+while a
+  ;
+  # next line
+
+for a in b
+  # preceding
+  ;
+
+for a in b
+  ; # trailing
+
+for a in b
+  ;
+  # next line
+
+switch
+  when b
+    # preceding
+    ;
+
+switch
+  when b
+    ; # trailing
+
+switch
+  when b
+    ;
+    # next line


### PR DESCRIPTION
In this PR:
- fix the parse-error-causing bug from #136 where empty `if` blocks with comments weren't printing the `;`

Not in this PR:
- didn't get positioning of comments relative to the `;` stabilized - this would seem to involve overriding how `printDanglingComments()` works because it seems to assume that it should print them on their own lines (rather than eg needing to keep `# eslint-disable-line` comments trailing on the same line)