### PR TITLE
Return inline if as condition

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -318,7 +318,8 @@ function pathNeedsParens(path, options, {stackOffset = 0} = {}) {
         isRightmost.isConsequent &&
         (node.alternate ||
           (isRightmost.isConsequent.ifNode &&
-            isRightmost.isConsequent.ifNode.alternate))
+            isRightmost.isConsequent.ifNode.alternate)) &&
+        parent.type !== 'ReturnStatement'
       ) {
         return {unlessParentBreaks: {visibleType: 'if'}}
       }

--- a/tests/parens/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/parens/__snapshots__/jsfmt.spec.js.snap
@@ -2069,6 +2069,27 @@ a(
 
 `;
 
+exports[`return-if.coffee 1`] = `
+if type is 'INTERPOLATION_START'
+  return if range[1] - range[0] is 1 then '{' else '#{'
+
+->
+  return if b then c
+
+->
+  return if b then c else d
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+if type is 'INTERPOLATION_START'
+  return (if range[1] - range[0] is 1 then '{' else '#{')
+
+->
+  return (if b then c)
+
+->
+  return (if b then c else d)
+
+`;
+
 exports[`spread-control-structure.coffee 1`] = `
 {
   ...(

--- a/tests/parens/return-if.coffee
+++ b/tests/parens/return-if.coffee
@@ -1,0 +1,8 @@
+if type is 'INTERPOLATION_START'
+  return if range[1] - range[0] is 1 then '{' else '#{'
+
+->
+  return if b then c
+
+->
+  return if b then c else d


### PR DESCRIPTION
Fixes #135 

In this PR:
- make sure that an inline `if` after a `return` gets parenthesized (so that it doesn't read as `return if` postfix if)