### PR TITLE
Optional/prototype shorthand member expression object spread parens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-plugin-coffeescript",
-  "version": "0.1.4",
+  "version": "0.1.5-dev.1",
   "description": "Prettier Coffeescript Plugin",
   "main": "src",
   "repository": "https://github.com/helixbass/prettier-plugin-coffeescript",

--- a/src/printer.js
+++ b/src/printer.js
@@ -116,6 +116,11 @@ function pathNeedsParens(path, options, {stackOffset = 0} = {}) {
       switch (parent.type) {
         case 'Range':
           return node.arguments && node.arguments.length > 0
+        case 'SpreadElement':
+          return (
+            grandparent.type === 'ObjectExpression' &&
+            node.type === 'OptionalCallExpression'
+          )
         default:
           return false
       }
@@ -560,8 +565,31 @@ function pathNeedsParens(path, options, {stackOffset = 0} = {}) {
           node === parent.arguments[0]
         )
       )
+    case 'MemberExpression':
+    case 'OptionalMemberExpression':
+      switch (parent.type) {
+        case 'SpreadElement':
+          return (
+            grandparent.type === 'ObjectExpression' &&
+            (node.type === 'OptionalMemberExpression' ||
+              containsPrototypeShorthand(node))
+          )
+        default:
+          return false
+      }
   }
 
+  return false
+}
+
+function containsPrototypeShorthand(node) {
+  let current = node
+  while (isMemberExpression(current)) {
+    if (current.shorthand) {
+      return true
+    }
+    current = current.object
+  }
   return false
 }
 

--- a/tests/parens/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/parens/__snapshots__/jsfmt.spec.js.snap
@@ -479,6 +479,59 @@ exports[`if-call-arg.coffee 1`] = `
 
 `;
 
+exports[`member-expression-spread.coffee 1`] = `
+export default class MyClass extends MyOtherClass
+  DEFAULTS: {
+    (@::DEFAULTS)...
+    a: 1
+    b: 1
+  }
+
+{(opts?.data?.root)..., (opts?.data)...}
+
+{
+  ...(a::b),
+  ...(a.b::c),
+  ...(a.b?.c),
+  ...(a().b?.c),
+  (a?())...,
+}
+
+f(a?.b...)
+f(a::b...)
+f(a?()...)
+
+[a?.b...]
+[a::b...]
+[a?()...]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export default class MyClass extends MyOtherClass
+  DEFAULTS: {
+    (@::DEFAULTS)...
+    a: 1
+    b: 1
+  }
+
+{ (opts?.data?.root)..., (opts?.data)... }
+
+{
+  ...(a::b)
+  ...(a.b::c)
+  ...(a.b?.c)
+  ...(a().b?.c)
+  (a?())...
+}
+
+f a?.b...
+f a::b...
+f a?()...
+
+[a?.b...]
+[a::b...]
+[a?()...]
+
+`;
+
 exports[`postfix-for-body-for.coffee 1`] = `
 (
   for a in b

--- a/tests/parens/member-expression-spread.coffee
+++ b/tests/parens/member-expression-spread.coffee
@@ -1,0 +1,24 @@
+export default class MyClass extends MyOtherClass
+  DEFAULTS: {
+    (@::DEFAULTS)...
+    a: 1
+    b: 1
+  }
+
+{(opts?.data?.root)..., (opts?.data)...}
+
+{
+  ...(a::b),
+  ...(a.b::c),
+  ...(a.b?.c),
+  ...(a().b?.c),
+  (a?())...,
+}
+
+f(a?.b...)
+f(a::b...)
+f(a?()...)
+
+[a?.b...]
+[a::b...]
+[a?()...]


### PR DESCRIPTION
Fixes #165 

This is definitely a Coffeescript parser bug (opened https://github.com/jashkenas/coffeescript/issues/5291)

But in the meantime we can add parens to safeguard against it